### PR TITLE
Remove redundant lib name in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,6 @@ edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [lib]
-name = "pybulletproofs"
 crate-type = ["cdylib"]
 
 [dependencies]


### PR DESCRIPTION
It defaults to package name.